### PR TITLE
bpar: true parallel subprocess execution with inline bundle config

### DIFF
--- a/stubs/FFI/SysFFI.cml
+++ b/stubs/FFI/SysFFI.cml
@@ -8,6 +8,7 @@ structure SysFFI = struct
       fun ffi_exec_process_io     x y = #(exec_process_io)      x y
       fun ffi_spawn_par_process   x y = #(spawn_par_process)    x y
       fun ffi_collect_par_process x y = #(collect_par_process)  x y
+      fun ffi_c_getpid            x y = #(c_getpid)             x y
   in
 
     (**
@@ -77,6 +78,18 @@ structure SysFFI = struct
       end
       handle Exception e => raise (Exception e)
            | _ => raise (Exception "Unknown Error thrown from c_collect_par_process")
+
+    (**
+     * c_getpid: Return the calling process's PID as an integer.
+     * Used to namespace par-handle temp files so subprocess CVM instances
+     * don't collide with the parent CVM's handle files (both reset loc to 0).
+     *)
+    fun c_getpid () =
+      let val zero_bs = BString.fromString "\000\000\000\000"
+          val resp    = FFI.call ffi_c_getpid 4 zero_bs
+      in
+        BString.qword_to_int resp
+      end
 
   end
 

--- a/stubs/FFI/SysFFI.cml
+++ b/stubs/FFI/SysFFI.cml
@@ -3,37 +3,81 @@
 structure SysFFI = struct
   exception Exception string
 
-  local 
-      fun ffi_system x y = #(system) x y
-      fun ffi_exec_process_io x y = #(exec_process_io) x y
+  local
+      fun ffi_system              x y = #(system)               x y
+      fun ffi_exec_process_io     x y = #(exec_process_io)      x y
+      fun ffi_spawn_par_process   x y = #(spawn_par_process)    x y
+      fun ffi_collect_par_process x y = #(collect_par_process)  x y
   in
+
     (**
      * c_exec_process_io: Spawn a process and communicate via stdin/stdout.
-     *
-     * The process at `process` is executed directly via fork/exec.
-     * `arg_str` is written to the process's stdin, then stdin is closed
-     * (sending EOF). The process's stdout is read and returned.
+     * Blocks until the child exits and returns its stdout.
      *
      * Input encoding sent to FFI:
      *   [ ProcessPathLength : 4 bytes (big-endian) ;
      *     ProcessPath       : ProcessPathLength bytes ;
      *     ArgString         : remaining bytes ]
-     *
-     * @param process  Absolute path to the executable
-     * @param arg_str  String to write to the process's stdin
-     * @return         The process's stdout output as a string
      *)
-    fun c_exec_process_io (process : string) (arg_str : string) = 
-      let val process_bs = BString.fromString process
+    fun c_exec_process_io (process : string) (arg_str : string) =
+      let val process_bs     = BString.fromString process
           val process_len_bs = BString.int_to_qword (BString.length process_bs)
-          val arg_bs = BString.fromString arg_str
-          val payload = BString.concat (BString.concat process_len_bs process_bs) arg_bs
-          val resp_bs = FFI.buffered_call ffi_exec_process_io payload
-      in 
+          val arg_bs         = BString.fromString arg_str
+          val payload        = BString.concat (BString.concat process_len_bs process_bs) arg_bs
+          val resp_bs        = FFI.buffered_call ffi_exec_process_io payload
+      in
         BString.toString resp_bs
       end
       handle Exception e => raise (Exception e)
            | _ => raise (Exception "Unknown Error thrown from c_exec_process_io, likely check that the word8 array is right length that is expected and not accessing something outside of its bounds")
+
+    (**
+     * c_spawn_par_process: Fork a subprocess non-blocking.
+     * Writes arg_str to the child's stdin, closes it, then returns immediately
+     * without waiting for the child.  Returns (stdout_read_fd, child_pid).
+     *
+     * FFI response (9 bytes):
+     *   [ SuccessCode  : 1 byte  ;
+     *     StdoutReadFd : 4 bytes (big-endian) ;
+     *     ChildPid     : 4 bytes (big-endian) ]
+     *)
+    fun c_spawn_par_process (process : string) (arg_str : string) =
+      let val process_bs     = BString.fromString process
+          val process_len_bs = BString.int_to_qword (BString.length process_bs)
+          val arg_bs         = BString.fromString arg_str
+          val payload        = BString.concat (BString.concat process_len_bs process_bs) arg_bs
+          val resp           = FFI.call ffi_spawn_par_process 9 payload
+          val status         = BString.hd resp
+          val body           = BString.tl resp
+          val fd             = BString.qword_to_int (BString.substring body 0 4)
+          val pid_v          = BString.qword_to_int (BString.substring body 4 4)
+      in
+        if status <> FFI.success
+        then raise (Exception ("c_spawn_par_process failed with status: "
+                               ^ Int.toString (Word8.toInt status)))
+        else (fd, pid_v)
+      end
+      handle Exception e => raise (Exception e)
+           | _ => raise (Exception "Unknown Error thrown from c_spawn_par_process")
+
+    (**
+     * c_collect_par_process: Block until the child spawned by
+     * c_spawn_par_process exits, then return its stdout as a string.
+     *
+     * Input:  (stdout_read_fd, child_pid) as returned by c_spawn_par_process
+     * Output: the child's stdout
+     *)
+    fun c_collect_par_process (pipe_read_fd : int) (pid_v : int) =
+      let val fd_bs   = BString.int_to_qword pipe_read_fd
+          val pid_bs  = BString.int_to_qword pid_v
+          val payload = BString.concat fd_bs pid_bs
+          val resp_bs = FFI.buffered_call ffi_collect_par_process payload
+      in
+        BString.toString resp_bs
+      end
+      handle Exception e => raise (Exception e)
+           | _ => raise (Exception "Unknown Error thrown from c_collect_par_process")
+
   end
 
 end

--- a/stubs/FFI/sys_ffi.c
+++ b/stubs/FFI/sys_ffi.c
@@ -626,6 +626,22 @@ void ffic_getpid(const char *in, const long ilen, char *a, const long alen)
   int_to_qword((int)getpid(), (unsigned char *)a);
 }
 
+/* ──────────────────────────────────────────────────────────────────────────
+ * ffic_getppid
+ *
+ * Returns the calling process's PARENT PID as a 4-byte big-endian integer.
+ * Used to namespace startup files: each subprocess CVM reads
+ * /tmp/cvm_startup_<ppid>.json to get its parent's configuration.
+ *
+ * Input:  ignored (pass 4 zero bytes)
+ * Output: [ PPID : 4 bytes (big-endian) ]
+ * ────────────────────────────────────────────────────────────────────────── */
+void ffic_getppid(const char *in, const long ilen, char *a, const long alen)
+{
+  if (a == NULL || alen < 4) return;
+  int_to_qword((int)getppid(), (unsigned char *)a);
+}
+
 void fficollect_par_process(const char *commandIn, const long clen, char *a, const long alen)
 {
   const uint8_t RESPONSE_CODE_START   = 0;

--- a/stubs/FFI/sys_ffi.c
+++ b/stubs/FFI/sys_ffi.c
@@ -459,3 +459,238 @@ void ffiexec_process_io(const char *commandIn, const long clen, char *a, const l
   a[RESPONSE_CODE_START] = SUCCESS;
   DEBUG_PRINTF("ffiexec_process_io: Function completed successfully\n");
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * ffispawn_par_process
+ *
+ * Non-blocking variant of ffiexec_process_io.  Forks the child, writes
+ * arg_str to its stdin (closing the write end so the child sees EOF), but
+ * does NOT call waitpid.  Returns the child's stdout read-fd and PID so the
+ * caller can retrieve the output later via fficollect_par_process.
+ *
+ * Input encoding  (same as ffiexec_process_io):
+ *   [ ProcessPathLength : 4 bytes (big-endian) ;
+ *     ProcessPath       : ProcessPathLength bytes ;
+ *     ArgString         : remaining bytes ]
+ *
+ * Output format (fixed 9 bytes):
+ *   [ SuccessCode   : 1 byte  ;
+ *     StdoutReadFd  : 4 bytes (big-endian) ;
+ *     ChildPid      : 4 bytes (big-endian) ]
+ *
+ * Return codes:  same as ffiexec_process_io
+ * ────────────────────────────────────────────────────────────────────────── */
+void ffispawn_par_process(const char *commandIn, const long clen, char *a, const long alen)
+{
+  /* Output is a fixed 9-byte header — no buffer manager needed. */
+  const int OUT_TOTAL  = 9;
+  const int FD_OFFSET  = 1;
+  const int PID_OFFSET = 5;
+
+  if (commandIn == NULL || a == NULL || alen < OUT_TOTAL || clen <= 0)
+  {
+    if (a != NULL && alen >= 1) a[0] = FILE_READ_ERROR;
+    return;
+  }
+  memset(a, 0, (size_t)alen);
+
+  /* ── Decode input ── */
+  if ((size_t)clen < 4)
+  {
+    a[0] = INPUT_DECODE_ERROR;
+    return;
+  }
+  int process_path_len = qword_to_int((unsigned char *)commandIn);
+  if (process_path_len <= 0)
+  {
+    a[0] = INPUT_DECODE_ERROR;
+    return;
+  }
+  size_t path_end = 4 + (size_t)process_path_len;
+  if (path_end > (size_t)clen)
+  {
+    a[0] = INPUT_DECODE_ERROR;
+    return;
+  }
+  char *process_path = malloc((size_t)process_path_len + 1);
+  if (!process_path) { a[0] = FAILED_TO_ALLOCATE_BUFFER; return; }
+  memcpy(process_path, commandIn + 4, (size_t)process_path_len);
+  process_path[process_path_len] = '\0';
+
+  const char *arg_str     = commandIn + path_end;
+  size_t      arg_str_len = (size_t)clen - path_end;
+
+  if (process_path[0] != '/' || strstr(process_path, "..") != NULL)
+  {
+    free(process_path);
+    a[0] = PATH_ERROR;
+    return;
+  }
+
+  /* ── Create pipes ── */
+  int stdin_pipe[2], stdout_pipe[2];
+  if (pipe(stdin_pipe) != 0)
+  {
+    free(process_path);
+    a[0] = PIPE_ERROR;
+    return;
+  }
+  if (pipe(stdout_pipe) != 0)
+  {
+    safe_close(stdin_pipe[0]); safe_close(stdin_pipe[1]);
+    free(process_path);
+    a[0] = PIPE_ERROR;
+    return;
+  }
+
+  /* ── Fork ── */
+  pid_t pid = fork();
+  if (pid < 0)
+  {
+    safe_close(stdin_pipe[0]); safe_close(stdin_pipe[1]);
+    safe_close(stdout_pipe[0]); safe_close(stdout_pipe[1]);
+    free(process_path);
+    a[0] = FORK_ERROR;
+    return;
+  }
+
+  if (pid == 0)
+  {
+    /* ── Child ── */
+    close(stdin_pipe[1]);
+    if (dup2(stdin_pipe[0], STDIN_FILENO) < 0) _exit(127);
+    close(stdin_pipe[0]);
+
+    close(stdout_pipe[0]);
+    if (dup2(stdout_pipe[1], STDOUT_FILENO) < 0) _exit(127);
+    close(stdout_pipe[1]);
+
+    execl(process_path, process_path, (char *)NULL);
+    fprintf(stderr, "ffispawn_par_process: execl failed for '%s': %s\n",
+            process_path, strerror(errno));
+    _exit(127);
+  }
+
+  /* ── Parent ── */
+  safe_close(stdin_pipe[0]);
+  safe_close(stdout_pipe[1]);
+  free(process_path);
+
+  /* Write arg_str to child's stdin and close (sends EOF). */
+  if (arg_str_len > 0)
+  {
+    if (write_all(stdin_pipe[1], arg_str, arg_str_len) != 0)
+    {
+      safe_close(stdin_pipe[1]);
+      safe_close(stdout_pipe[0]);
+      waitpid(pid, NULL, 0);
+      a[0] = STDIN_WRITE_ERROR;
+      return;
+    }
+  }
+  safe_close(stdin_pipe[1]); /* EOF → child can finish reading stdin */
+
+  /* Return the stdout read-fd and PID — do NOT waitpid here. */
+  a[0] = SUCCESS;
+  int_to_qword((int)stdout_pipe[0], (unsigned char *)&a[FD_OFFSET]);
+  int_to_qword((int)pid,            (unsigned char *)&a[PID_OFFSET]);
+  DEBUG_PRINTF("ffispawn_par_process: spawned pid=%d stdout_fd=%d\n", pid, stdout_pipe[0]);
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * fficollect_par_process
+ *
+ * Blocks until the child whose stdout read-fd and PID were returned by
+ * ffispawn_par_process has exited, reads its stdout, and returns the output
+ * via the buffer-manager protocol (identical to ffiexec_process_io output).
+ *
+ * Input  (8 bytes):
+ *   [ StdoutReadFd : 4 bytes (big-endian) ;
+ *     ChildPid     : 4 bytes (big-endian) ]
+ *
+ * Output: same buffer-manager header as ffiexec_process_io.
+ * ────────────────────────────────────────────────────────────────────────── */
+void fficollect_par_process(const char *commandIn, const long clen, char *a, const long alen)
+{
+  const uint8_t RESPONSE_CODE_START   = 0;
+  const uint8_t OUTPUT_LENGTH_START   = 1;
+  const uint8_t OUTPUT_BUFFER_ID_START = 5;
+  const uint8_t HEADER_LENGTH         = 9;
+
+  if (commandIn == NULL || a == NULL || alen < HEADER_LENGTH || clen < 8)
+  {
+    if (a != NULL && alen >= 1) a[0] = INPUT_DECODE_ERROR;
+    return;
+  }
+  memset(a, 0, (size_t)alen);
+
+  int pipe_read_fd = qword_to_int((unsigned char *)commandIn);
+  int pid          = qword_to_int((unsigned char *)(commandIn + 4));
+  DEBUG_PRINTF("fficollect_par_process: collecting from fd=%d pid=%d\n", pipe_read_fd, pid);
+
+  /* ── Read child stdout ── */
+  FILE *child_stdout = fdopen(pipe_read_fd, "r");
+  if (child_stdout == NULL)
+  {
+    DEBUG_PRINTF("fficollect_par_process: fdopen failed: %s\n", strerror(errno));
+    a[RESPONSE_CODE_START] = FILE_READ_ERROR;
+    return;
+  }
+
+  char  *buffer        = NULL;
+  size_t output_length = 0;
+  uint8_t out_code = read_until_eof(child_stdout, 4096, &buffer, &output_length);
+  fclose(child_stdout); /* also closes pipe_read_fd */
+
+  /* ── Wait for child ── */
+  int status = 0;
+  pid_t wp;
+  do { wp = waitpid(pid, &status, 0); } while (wp < 0 && errno == EINTR);
+
+  if (wp < 0)
+  {
+    if (buffer) free(buffer);
+    a[RESPONSE_CODE_START] = FILE_READ_ERROR;
+    return;
+  }
+  if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
+  {
+    DEBUG_PRINTF("fficollect_par_process: child exited with code %d\n", WEXITSTATUS(status));
+    if (buffer) free(buffer);
+    a[RESPONSE_CODE_START] = FILE_CLOSE_ERROR;
+    return;
+  }
+  if (WIFSIGNALED(status))
+  {
+    DEBUG_PRINTF("fficollect_par_process: child killed by signal %d\n", WTERMSIG(status));
+    if (buffer) free(buffer);
+    a[RESPONSE_CODE_START] = FILE_CLOSE_ERROR;
+    return;
+  }
+
+  if (out_code != SUCCESS || buffer == NULL)
+  {
+    if (buffer) free(buffer);
+    a[RESPONSE_CODE_START] = (out_code != SUCCESS) ? out_code : FAILED_TO_ALLOCATE_BUFFER;
+    return;
+  }
+  if (output_length > UINT32_MAX)
+  {
+    free(buffer);
+    a[RESPONSE_CODE_START] = NEED_MORE_THAN_32_BITS_FOR_LENGTH;
+    return;
+  }
+
+  int buffer_id = set_new_buffer((long)output_length, buffer);
+  if (buffer_id < 0)
+  {
+    free(buffer);
+    a[RESPONSE_CODE_START] = FAILED_TO_ALLOCATE_BUFFER;
+    return;
+  }
+
+  int_to_qword((int)output_length, (unsigned char *)&a[OUTPUT_LENGTH_START]);
+  int_to_qword(buffer_id,          (unsigned char *)&a[OUTPUT_BUFFER_ID_START]);
+  a[RESPONSE_CODE_START] = SUCCESS;
+  DEBUG_PRINTF("fficollect_par_process: collected %zu bytes from pid=%d\n", output_length, pid);
+}

--- a/stubs/FFI/sys_ffi.c
+++ b/stubs/FFI/sys_ffi.c
@@ -610,6 +610,22 @@ void ffispawn_par_process(const char *commandIn, const long clen, char *a, const
  *
  * Output: same buffer-manager header as ffiexec_process_io.
  * ────────────────────────────────────────────────────────────────────────── */
+/* ──────────────────────────────────────────────────────────────────────────
+ * ffic_getpid
+ *
+ * Returns the calling process's PID as a 4-byte big-endian integer.
+ * Used to namespace par-handle temp files so subprocess CVMs don't
+ * collide with the parent's handle files when both use loc=0,1,…
+ *
+ * Input:  ignored (pass 4 zero bytes)
+ * Output: [ PID : 4 bytes (big-endian) ]
+ * ────────────────────────────────────────────────────────────────────────── */
+void ffic_getpid(const char *in, const long ilen, char *a, const long alen)
+{
+  if (a == NULL || alen < 4) return;
+  int_to_qword((int)getpid(), (unsigned char *)a);
+}
+
 void fficollect_par_process(const char *commandIn, const long clen, char *a, const long alen)
 {
   const uint8_t RESPONSE_CODE_START   = 0;

--- a/stubs/IO_Axioms.cml
+++ b/stubs/IO_Axioms.cml
@@ -1,4 +1,4 @@
-(* deps: AM_Handler Attestation_Session ID_Type Interface_JSON Interface_String_Vars Interface_Types JSON JSON_Stringifiable JSON_Type Manifest_TCs ResultMonad St Stringifiable System_Types Term_Defs_Core Term_Defs_Core_Typeclasses Coq_TextIO ExtractionPrelude $FFI.SocketFFI $FFI.SysFFI $JSON_Axioms *)
+(* deps: Attestation_Session ID_Type Interface_JSON Interface_String_Vars Interface_Types JSON JSON_Stringifiable JSON_Type Manifest_TCs ResultMonad St Stringifiable System_Types Term_Defs_Core Term_Defs_Core_Typeclasses Coq_TextIO ExtractionPrelude $FFI.SocketFFI $FFI.SysFFI $JSON_Axioms *)
 
 structure IO_Axioms = struct
  (** val make_network_request :
@@ -139,7 +139,8 @@ structure IO_Axioms = struct
           (St.Coq_dispatch_error (Attestation_Session.Runtime msg))
 
       (* ── Step 1: Read and parse the startup file ─────────────────── *)
-      val startup_str = Coq_TextIO.TextIO.readFile AM_Handler.coq_CVM_STARTUP_FILE
+      (* Must match AM_Handler.CVM_STARTUP_FILE — inlined to avoid circular dep *)
+      val startup_str = Coq_TextIO.TextIO.readFile "/tmp/cvm_startup.json"
     in
       case js_from_str startup_str of
         ResultMonad.Coq_err e =>

--- a/stubs/IO_Axioms.cml
+++ b/stubs/IO_Axioms.cml
@@ -1,4 +1,4 @@
-(* deps: ResultMonad St System_Types Term_Defs_Core ExtractionPrelude $FFI.SocketFFI $FFI.SysFFI $JSON_Axioms *)
+(* deps: AM_Handler Attestation_Session ID_Type Interface_JSON Interface_String_Vars Interface_Types JSON JSON_Stringifiable JSON_Type Manifest_TCs ResultMonad St Stringifiable System_Types Term_Defs_Core Term_Defs_Core_Typeclasses Coq_TextIO ExtractionPrelude $FFI.SocketFFI $FFI.SysFFI $JSON_Axioms *)
 
 structure IO_Axioms = struct
  (** val make_network_request :
@@ -76,8 +76,111 @@ structure IO_Axioms = struct
                           (Term_Defs_Core.coq_Evidence, St.coq_CVM_Error)
                           ResultMonad.coq_Result) =
     fn loc => fn plc => fn ev => fn term =>
-      ResultMonad.Coq_err 
-        (St.Coq_dispatch_error 
-          (Attestation_Session.Runtime "PARALLEL VM THREAD NOT IMPLEMENTED"))
-   (* failwith "AXIOM TO BE REALIZED (CVM.IO_Axioms.parallel_vm_thread)" *)
+    let
+      (* ── Typeclass instances ─────────────────────────────────────── *)
+
+      (* Attestation_Session JSON *)
+      val plc_map_json =
+        JSON.jsonifiable_map_serial_json
+          ID_Type.coq_Stringifiable_ID_Type
+          ID_Type.coq_DecEq_ID_Type
+          (ID_Type.coq_Jsonifiable_ID_Type ID_Type.coq_Stringifiable_ID_Type)
+
+      val global_ctx_json =
+        Term_Defs_Core_Typeclasses.coq_Jsonifiable_GlobalContext
+          ID_Type.coq_Stringifiable_ID_Type
+          plc_map_json
+          (JSON.jsonifiable_map_serial_json
+            ID_Type.coq_Stringifiable_ID_Type
+            ID_Type.coq_DecEq_ID_Type
+            (Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvSig
+              (Term_Defs_Core_Typeclasses.coq_Jsonifiable_list_Attr
+                Term_Defs_Core_Typeclasses.coq_Jsonifiable_Attr)
+              Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvCombSig))
+
+      val att_sess_json =
+        Attestation_Session.coq_Jsonifiable_Attestation_Session
+          plc_map_json plc_map_json global_ctx_json
+
+      (* Evidence JSON *)
+      val ev_type_json =
+        Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvidenceT
+          ID_Type.coq_Stringifiable_ID_Type
+          Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS
+          JSON.coq_Jsonifiable_nat
+          (Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_Params
+            Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS)
+
+      val evidence_json =
+        Term_Defs_Core_Typeclasses.coq_Jsonifiable_Evidence
+          Term_Defs_Core_Typeclasses.coq_Jsonifiable_RawEv ev_type_json
+
+      (* Term JSON *)
+      val term_json =
+        Term_Defs_Core_Typeclasses.coq_Jsonifiable_Term
+          (Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP
+            Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS)
+
+      (* ProtocolRunRequest / Response JSON *)
+      val prreq_json =
+        Interface_JSON.coq_Jsonifiable_ProtocolRunRequest
+          term_json evidence_json att_sess_json
+
+      val prresp_json =
+        Interface_JSON.coq_Jsonifiable_ProtocolRunResponse evidence_json
+
+      (* JSON string serializer/parser *)
+      val Stringifiable.Build_Stringifiable js_to_str js_from_str =
+        JSON_Stringifiable.coq_Stringifiable_JSON
+
+      (* ── Helper: dispatch error ──────────────────────────────────── *)
+      fun dispatch_err msg =
+        ResultMonad.Coq_err
+          (St.Coq_dispatch_error (Attestation_Session.Runtime msg))
+
+      (* ── Step 1: Read and parse the startup file ─────────────────── *)
+      val startup_str = Coq_TextIO.TextIO.readFile AM_Handler.coq_CVM_STARTUP_FILE
+    in
+      case js_from_str startup_str of
+        ResultMonad.Coq_err e =>
+          dispatch_err ("parallel_vm_thread: failed to parse startup file: " ^ e)
+      | ResultMonad.Coq_res startup_js =>
+      (* ── Step 2: Extract cvm_binary and att_sess ─────────────────── *)
+      case JSON.coq_JSON_get_string "cvm_binary" startup_js of
+        ResultMonad.Coq_err e =>
+          dispatch_err ("parallel_vm_thread: missing cvm_binary in startup file: " ^ e)
+      | ResultMonad.Coq_res cvm_binary =>
+      case JSON.coq_JSON_get_Object "att_sess" startup_js of
+        ResultMonad.Coq_err e =>
+          dispatch_err ("parallel_vm_thread: missing att_sess in startup file: " ^ e)
+      | ResultMonad.Coq_res att_sess_obj =>
+      let val JSON.Build_Jsonifiable _ att_sess_from_json = att_sess_json in
+      case att_sess_from_json att_sess_obj of
+        ResultMonad.Coq_err e =>
+          dispatch_err ("parallel_vm_thread: failed to deserialize att_sess: " ^ e)
+      | ResultMonad.Coq_res att_sess =>
+      (* ── Step 3: Build ProtocolRunRequest for the parallel branch ── *)
+      let
+        val req = Interface_Types.Coq_mkPRReq att_sess plc ev term
+        val JSON.Build_Jsonifiable prreq_to_json _ = prreq_json
+        val req_str = js_to_str (prreq_to_json req)
+        (* ── Step 4: Spawn subprocess CVM synchronously ───────────── *)
+        val resp_str = SysFFI.c_exec_process_io cvm_binary req_str
+      in
+      (* ── Step 5: Parse response and extract evidence ─────────────── *)
+      case js_from_str resp_str of
+        ResultMonad.Coq_err e =>
+          dispatch_err ("parallel_vm_thread: failed to parse subprocess response: " ^ e)
+      | ResultMonad.Coq_res resp_js =>
+      let val JSON.Build_Jsonifiable _ prresp_from_json = prresp_json in
+      case prresp_from_json resp_js of
+        ResultMonad.Coq_err e =>
+          dispatch_err ("parallel_vm_thread: failed to deserialize response: " ^ e)
+      | ResultMonad.Coq_res resp =>
+        ResultMonad.Coq_res
+          (let val Interface_Types.Coq_mkPRResp _ ev_out = resp in ev_out end)
+      end
+      end
+      end
+    end
 end

--- a/stubs/IO_Axioms.cml
+++ b/stubs/IO_Axioms.cml
@@ -177,8 +177,12 @@ structure IO_Axioms = struct
     containing "<fd>\n<pid>" so no mutable CML state is needed.
     ──────────────────────────────────────────────────────────────────────── *)
 
+ (* Include the calling process's PID in the handle file name so that
+    nested bpar subprocesses (which reset st_evid to 0 and thus reuse
+    loc=0,1,…) don't overwrite the parent CVM's handle files.
+    Each CVM process writes and reads only its own PID-namespaced files. *)
  fun par_handle_path (loc : int) =
-   "/tmp/cvm_par_" ^ Int.toString loc ^ ".handle"
+   "/tmp/cvm_par_" ^ Int.toString (SysFFI.c_getpid ()) ^ "_" ^ Int.toString loc ^ ".handle"
 
  fun par_write_handle (loc : int) (fd : int) (pid_v : int) =
    Coq_TextIO.TextIO.writeFile (par_handle_path loc)

--- a/stubs/IO_Axioms.cml
+++ b/stubs/IO_Axioms.cml
@@ -5,9 +5,9 @@ structure IO_Axioms = struct
      System_Types.coq_IP_Port -> string -> (string, string)
      ResultMonad.coq_Result **)
 
-    fun decodeUUID (u : System_Types.coq_IP_Port) = 
+    fun decodeUUID (u : System_Types.coq_IP_Port) =
       (* Splits at ":" character, into (ip, port) *)
-      let val colonInt = 
+      let val colonInt =
             case (String.findi (fn c => (Char.chr 58) = c) 0 u) of
               None => raise FalseException "Unable to decode UUID, no splitting ':' found"
               | Some v => v
@@ -24,7 +24,7 @@ structure IO_Axioms = struct
   val make_network_request : (System_Types.coq_IP_Port -> string -> (string,
                             string) ResultMonad.coq_Result) =
     (fn ipport => fn reqstr =>
-    let 
+    let
       val (ip, port) = decodeUUID ipport
       (* val _ = print ("Decoded UUID to: " ^ ip ^ ":" ^ (Int.toString port) ^ "\n") *)
       val socket = SocketFFI.connect ip port
@@ -47,7 +47,7 @@ structure IO_Axioms = struct
   val make_fs_request : (System_Types.coq_FS_Location -> string -> (string,
                        string) ResultMonad.coq_Result) =
     (fn path => fn reqstr =>
-      (let 
+      (let
         (* val _ = print ("Sending a request to the FS: " ^ path ^ "\n") *)
         val resp = SysFFI.c_exec_process_io path reqstr
         (* val _ = print ("Got back a response from the ASP: \n" ^ resp ^ "\n") *)
@@ -65,11 +65,20 @@ structure IO_Axioms = struct
     (fn a => a)
    (* failwith "AXIOM TO BE REALIZED (CVM.IO_Axioms.aspid_to_fs_location)" *)
 
+ (* ── Shared typeclass-instance builder ────────────────────────────────────
+    Both parallel_vm_thread (Phase 1 sequential) and start_par_subprocess
+    (Phase 2) need the same JSON typeclass instances and startup-file logic.
+    We keep them as inline let-bindings in each function (copy-paste) to
+    avoid introducing a helper that would need its own bake ordering.
+    ──────────────────────────────────────────────────────────────────────── *)
+
  (** val parallel_vm_thread :
      Term_Defs_Core.coq_Loc -> Term_Defs_Core.coq_Plc ->
      Term_Defs_Core.coq_Evidence -> Term_Defs_Core.coq_Term ->
      (Term_Defs_Core.coq_Evidence, St.coq_CVM_Error) ResultMonad.coq_Result **)
 
+ (* Phase 1 sequential implementation — kept for reference; no longer called
+    from the Rocq side in Phase 2 (superseded by start/collect below). *)
  val parallel_vm_thread : (Term_Defs_Core.coq_Loc -> Term_Defs_Core.coq_Plc
                           -> Term_Defs_Core.coq_Evidence ->
                           Term_Defs_Core.coq_Term ->
@@ -78,14 +87,11 @@ structure IO_Axioms = struct
     fn loc => fn plc => fn ev => fn term =>
     let
       (* ── Typeclass instances ─────────────────────────────────────── *)
-
-      (* Attestation_Session JSON *)
       val plc_map_json =
         JSON.jsonifiable_map_serial_json
           ID_Type.coq_Stringifiable_ID_Type
           ID_Type.coq_DecEq_ID_Type
           (ID_Type.coq_Jsonifiable_ID_Type ID_Type.coq_Stringifiable_ID_Type)
-
       val global_ctx_json =
         Term_Defs_Core_Typeclasses.coq_Jsonifiable_GlobalContext
           ID_Type.coq_Stringifiable_ID_Type
@@ -97,12 +103,9 @@ structure IO_Axioms = struct
               (Term_Defs_Core_Typeclasses.coq_Jsonifiable_list_Attr
                 Term_Defs_Core_Typeclasses.coq_Jsonifiable_Attr)
               Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvCombSig))
-
       val att_sess_json =
         Attestation_Session.coq_Jsonifiable_Attestation_Session
           plc_map_json plc_map_json global_ctx_json
-
-      (* Evidence JSON *)
       val ev_type_json =
         Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvidenceT
           ID_Type.coq_Stringifiable_ID_Type
@@ -110,43 +113,29 @@ structure IO_Axioms = struct
           JSON.coq_Jsonifiable_nat
           (Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_Params
             Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS)
-
       val evidence_json =
         Term_Defs_Core_Typeclasses.coq_Jsonifiable_Evidence
           Term_Defs_Core_Typeclasses.coq_Jsonifiable_RawEv ev_type_json
-
-      (* Term JSON *)
       val term_json =
         Term_Defs_Core_Typeclasses.coq_Jsonifiable_Term
           (Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP
             Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS)
-
-      (* ProtocolRunRequest / Response JSON *)
       val prreq_json =
         Interface_JSON.coq_Jsonifiable_ProtocolRunRequest
           term_json evidence_json att_sess_json
-
       val prresp_json =
         Interface_JSON.coq_Jsonifiable_ProtocolRunResponse evidence_json
-
-      (* JSON string serializer/parser *)
       val Stringifiable.Build_Stringifiable js_to_str js_from_str =
         JSON_Stringifiable.coq_Stringifiable_JSON
-
-      (* ── Helper: dispatch error ──────────────────────────────────── *)
       fun dispatch_err msg =
         ResultMonad.Coq_err
           (St.Coq_dispatch_error (Attestation_Session.Runtime msg))
-
-      (* ── Step 1: Read and parse the startup file ─────────────────── *)
-      (* Must match AM_Handler.CVM_STARTUP_FILE — inlined to avoid circular dep *)
       val startup_str = Coq_TextIO.TextIO.readFile "/tmp/cvm_startup.json"
     in
       case js_from_str startup_str of
         ResultMonad.Coq_err e =>
           dispatch_err ("parallel_vm_thread: failed to parse startup file: " ^ e)
       | ResultMonad.Coq_res startup_js =>
-      (* ── Step 2: Extract cvm_binary and att_sess ─────────────────── *)
       case JSON.coq_JSON_get_string "cvm_binary" startup_js of
         ResultMonad.Coq_err e =>
           dispatch_err ("parallel_vm_thread: missing cvm_binary in startup file: " ^ e)
@@ -160,15 +149,12 @@ structure IO_Axioms = struct
         ResultMonad.Coq_err e =>
           dispatch_err ("parallel_vm_thread: failed to deserialize att_sess: " ^ e)
       | ResultMonad.Coq_res att_sess =>
-      (* ── Step 3: Build ProtocolRunRequest for the parallel branch ── *)
       let
         val req = Interface_Types.Coq_mkPRReq att_sess plc ev term
         val JSON.Build_Jsonifiable prreq_to_json _ = prreq_json
         val req_str = js_to_str (prreq_to_json req)
-        (* ── Step 4: Spawn subprocess CVM synchronously ───────────── *)
         val resp_str = SysFFI.c_exec_process_io cvm_binary req_str
       in
-      (* ── Step 5: Parse response and extract evidence ─────────────── *)
       case js_from_str resp_str of
         ResultMonad.Coq_err e =>
           dispatch_err ("parallel_vm_thread: failed to parse subprocess response: " ^ e)
@@ -184,4 +170,192 @@ structure IO_Axioms = struct
       end
       end
     end
+
+ (* ── Phase 2: split spawn / collect ──────────────────────────────────────
+    coq_Loc extracts to CML int, so we use it directly.
+    Handles are stored in per-loc temp files: /tmp/cvm_par_<loc>.handle
+    containing "<fd>\n<pid>" so no mutable CML state is needed.
+    ──────────────────────────────────────────────────────────────────────── *)
+
+ fun par_handle_path (loc : int) =
+   "/tmp/cvm_par_" ^ Int.toString loc ^ ".handle"
+
+ fun par_write_handle (loc : int) (fd : int) (pid_v : int) =
+   Coq_TextIO.TextIO.writeFile (par_handle_path loc)
+     (Int.toString fd ^ "\n" ^ Int.toString pid_v)
+
+ fun par_read_handle (loc : int) =
+   let val content = Coq_TextIO.TextIO.readFile (par_handle_path loc)
+       val parts   = String.tokens (fn c => c = #"\n") content
+   in
+     case parts of
+       [fd_s, pid_s] =>
+         (case (Int.fromString fd_s, Int.fromString pid_s) of
+           (Some fd, Some pid_v) => Some (fd, pid_v)
+         | _ => None)
+     | _ => None
+   end
+
+ (** val start_par_subprocess :
+     Term_Defs_Core.coq_Loc -> Term_Defs_Core.coq_Plc ->
+     Term_Defs_Core.coq_Evidence -> Term_Defs_Core.coq_Term ->
+     (unit, St.coq_CVM_Error) ResultMonad.coq_Result **)
+
+ val start_par_subprocess : (Term_Defs_Core.coq_Loc -> Term_Defs_Core.coq_Plc
+                            -> Term_Defs_Core.coq_Evidence ->
+                            Term_Defs_Core.coq_Term ->
+                            (unit, St.coq_CVM_Error) ResultMonad.coq_Result) =
+   fn loc => fn plc => fn ev => fn term =>
+   let
+     (* ── Typeclass instances (copy of parallel_vm_thread) ─────────── *)
+     val plc_map_json =
+       JSON.jsonifiable_map_serial_json
+         ID_Type.coq_Stringifiable_ID_Type
+         ID_Type.coq_DecEq_ID_Type
+         (ID_Type.coq_Jsonifiable_ID_Type ID_Type.coq_Stringifiable_ID_Type)
+     val global_ctx_json =
+       Term_Defs_Core_Typeclasses.coq_Jsonifiable_GlobalContext
+         ID_Type.coq_Stringifiable_ID_Type
+         plc_map_json
+         (JSON.jsonifiable_map_serial_json
+           ID_Type.coq_Stringifiable_ID_Type
+           ID_Type.coq_DecEq_ID_Type
+           (Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvSig
+             (Term_Defs_Core_Typeclasses.coq_Jsonifiable_list_Attr
+               Term_Defs_Core_Typeclasses.coq_Jsonifiable_Attr)
+             Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvCombSig))
+     val att_sess_json =
+       Attestation_Session.coq_Jsonifiable_Attestation_Session
+         plc_map_json plc_map_json global_ctx_json
+     val ev_type_json =
+       Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvidenceT
+         ID_Type.coq_Stringifiable_ID_Type
+         Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS
+         JSON.coq_Jsonifiable_nat
+         (Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_Params
+           Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS)
+     val evidence_json =
+       Term_Defs_Core_Typeclasses.coq_Jsonifiable_Evidence
+         Term_Defs_Core_Typeclasses.coq_Jsonifiable_RawEv ev_type_json
+     val term_json =
+       Term_Defs_Core_Typeclasses.coq_Jsonifiable_Term
+         (Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP
+           Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS)
+     val prreq_json =
+       Interface_JSON.coq_Jsonifiable_ProtocolRunRequest
+         term_json evidence_json att_sess_json
+     val Stringifiable.Build_Stringifiable js_to_str js_from_str =
+       JSON_Stringifiable.coq_Stringifiable_JSON
+     fun dispatch_err msg =
+       ResultMonad.Coq_err
+         (St.Coq_dispatch_error (Attestation_Session.Runtime msg))
+     (* ── Step 1: Read and parse the startup file ──────────────────── *)
+     val startup_str = Coq_TextIO.TextIO.readFile "/tmp/cvm_startup.json"
+   in
+     case js_from_str startup_str of
+       ResultMonad.Coq_err e =>
+         dispatch_err ("start_par_subprocess: failed to parse startup file: " ^ e)
+     | ResultMonad.Coq_res startup_js =>
+     (* ── Step 2: Extract cvm_binary and att_sess ──────────────────── *)
+     case JSON.coq_JSON_get_string "cvm_binary" startup_js of
+       ResultMonad.Coq_err e =>
+         dispatch_err ("start_par_subprocess: missing cvm_binary in startup file: " ^ e)
+     | ResultMonad.Coq_res cvm_binary =>
+     case JSON.coq_JSON_get_Object "att_sess" startup_js of
+       ResultMonad.Coq_err e =>
+         dispatch_err ("start_par_subprocess: missing att_sess in startup file: " ^ e)
+     | ResultMonad.Coq_res att_sess_obj =>
+     let val JSON.Build_Jsonifiable _ att_sess_from_json = att_sess_json in
+     case att_sess_from_json att_sess_obj of
+       ResultMonad.Coq_err e =>
+         dispatch_err ("start_par_subprocess: failed to deserialize att_sess: " ^ e)
+     | ResultMonad.Coq_res att_sess =>
+     (* ── Step 3: Build ProtocolRunRequest ─────────────────────────── *)
+     let
+       val req = Interface_Types.Coq_mkPRReq att_sess plc ev term
+       val JSON.Build_Jsonifiable prreq_to_json _ = prreq_json
+       val req_str = js_to_str (prreq_to_json req)
+       (* ── Step 4: Non-blocking fork — returns (fd, pid) immediately ─ *)
+       val (fd, pid) = SysFFI.c_spawn_par_process cvm_binary req_str
+       (* ── Step 5: Persist handle to temp file indexed by loc ──────── *)
+       val _ = par_write_handle loc fd pid
+     in
+       ResultMonad.Coq_res ()
+     end
+     end
+   end
+
+ (** val collect_par_subprocess :
+     Term_Defs_Core.coq_Loc -> Term_Defs_Core.coq_Plc ->
+     Term_Defs_Core.coq_Evidence -> Term_Defs_Core.coq_Term ->
+     (Term_Defs_Core.coq_Evidence, St.coq_CVM_Error) ResultMonad.coq_Result **)
+
+ val collect_par_subprocess : (Term_Defs_Core.coq_Loc -> Term_Defs_Core.coq_Plc
+                              -> Term_Defs_Core.coq_Evidence ->
+                              Term_Defs_Core.coq_Term ->
+                              (Term_Defs_Core.coq_Evidence, St.coq_CVM_Error)
+                              ResultMonad.coq_Result) =
+   fn loc => fn plc => fn ev => fn term =>
+   let
+     (* ── Typeclass instances (copy of parallel_vm_thread) ─────────── *)
+     val plc_map_json =
+       JSON.jsonifiable_map_serial_json
+         ID_Type.coq_Stringifiable_ID_Type
+         ID_Type.coq_DecEq_ID_Type
+         (ID_Type.coq_Jsonifiable_ID_Type ID_Type.coq_Stringifiable_ID_Type)
+     val global_ctx_json =
+       Term_Defs_Core_Typeclasses.coq_Jsonifiable_GlobalContext
+         ID_Type.coq_Stringifiable_ID_Type
+         plc_map_json
+         (JSON.jsonifiable_map_serial_json
+           ID_Type.coq_Stringifiable_ID_Type
+           ID_Type.coq_DecEq_ID_Type
+           (Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvSig
+             (Term_Defs_Core_Typeclasses.coq_Jsonifiable_list_Attr
+               Term_Defs_Core_Typeclasses.coq_Jsonifiable_Attr)
+             Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvCombSig))
+     val att_sess_json =
+       Attestation_Session.coq_Jsonifiable_Attestation_Session
+         plc_map_json plc_map_json global_ctx_json
+     val ev_type_json =
+       Term_Defs_Core_Typeclasses.coq_Jsonifiable_EvidenceT
+         ID_Type.coq_Stringifiable_ID_Type
+         Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS
+         JSON.coq_Jsonifiable_nat
+         (Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_Params
+           Term_Defs_Core_Typeclasses.coq_Jsonifiable_ASP_ARGS)
+     val evidence_json =
+       Term_Defs_Core_Typeclasses.coq_Jsonifiable_Evidence
+         Term_Defs_Core_Typeclasses.coq_Jsonifiable_RawEv ev_type_json
+     val prresp_json =
+       Interface_JSON.coq_Jsonifiable_ProtocolRunResponse evidence_json
+     val Stringifiable.Build_Stringifiable js_to_str js_from_str =
+       JSON_Stringifiable.coq_Stringifiable_JSON
+     fun dispatch_err msg =
+       ResultMonad.Coq_err
+         (St.Coq_dispatch_error (Attestation_Session.Runtime msg))
+     (* ── Step 1: Read the handle for this loc from temp file ────────── *)
+   in
+     case par_read_handle loc of
+       None =>
+         dispatch_err ("collect_par_subprocess: no handle for loc " ^ Int.toString loc)
+     | Some (fd, pid) =>
+     (* ── Step 2: Block until subprocess exits, read its stdout ──────── *)
+     let val resp_str = SysFFI.c_collect_par_process fd pid in
+     (* ── Step 3: Parse response and extract evidence ──────────────── *)
+     case js_from_str resp_str of
+       ResultMonad.Coq_err e =>
+         dispatch_err ("collect_par_subprocess: failed to parse subprocess response: " ^ e)
+     | ResultMonad.Coq_res resp_js =>
+     let val JSON.Build_Jsonifiable _ prresp_from_json = prresp_json in
+     case prresp_from_json resp_js of
+       ResultMonad.Coq_err e =>
+         dispatch_err ("collect_par_subprocess: failed to deserialize response: " ^ e)
+     | ResultMonad.Coq_res resp =>
+       ResultMonad.Coq_res
+         (let val Interface_Types.Coq_mkPRResp _ ev_out = resp in ev_out end)
+     end
+     end
+   end
+
 end

--- a/stubs/IO_Axioms.cml
+++ b/stubs/IO_Axioms.cml
@@ -185,8 +185,9 @@ structure IO_Axioms = struct
    "/tmp/cvm_par_" ^ Int.toString (SysFFI.c_getpid ()) ^ "_" ^ Int.toString loc ^ ".handle"
 
  fun par_write_handle (loc : int) (fd : int) (pid_v : int) =
-   Coq_TextIO.TextIO.writeFile (par_handle_path loc)
-     (Int.toString fd ^ "\n" ^ Int.toString pid_v)
+   let val s = TextIO.openOut (par_handle_path loc)
+       val _ = TextIO.output s (Int.toString fd ^ "\n" ^ Int.toString pid_v)
+   in TextIO.closeOut s end
 
  fun par_read_handle (loc : int) =
    let val content = Coq_TextIO.TextIO.readFile (par_handle_path loc)
@@ -203,15 +204,26 @@ structure IO_Axioms = struct
  (** val start_par_subprocess :
      Term_Defs_Core.coq_Loc -> Term_Defs_Core.coq_Plc ->
      Term_Defs_Core.coq_Evidence -> Term_Defs_Core.coq_Term ->
-     (unit, St.coq_CVM_Error) ResultMonad.coq_Result **)
+     St.coq_CVM_Config -> St.cvm_st ->
+     (unit, St.coq_CVM_Error) ResultMonad.coq_Result * St.cvm_st **)
 
+ (* Option B: no startup file.  The full config is carried in the CVM monad
+    reader environment (cfg).  We build an inline bundle JSON containing
+    cvm_binary, manifest, asp_bin, and the ProtocolRunRequest, and send it
+    to the subprocess CVM on stdin.  The subprocess FrontEnd reads this
+    single blob and needs no separate startup file. *)
  val start_par_subprocess : (Term_Defs_Core.coq_Loc -> Term_Defs_Core.coq_Plc
                             -> Term_Defs_Core.coq_Evidence ->
-                            Term_Defs_Core.coq_Term ->
-                            (unit, St.coq_CVM_Error) ResultMonad.coq_Result) =
-   fn loc => fn plc => fn ev => fn term =>
+                            Term_Defs_Core.coq_Term -> St.coq_CVM_Config ->
+                            St.cvm_st ->
+                            (unit, St.coq_CVM_Error) ResultMonad.coq_Result * St.cvm_st) =
+   fn loc => fn plc => fn ev => fn term => fn cfg => fn st =>
    let
-     (* ── Typeclass instances (copy of parallel_vm_thread) ─────────── *)
+     (* ── Extract config from CVM monad reader environment ─────────── *)
+     val St.Coq_mk_cvm_cfg cc_session cc_asp_bin cc_cvm_bin cc_manifest = cfg
+     (* ── Reconstruct att_sess from Session_Config ──────────────────── *)
+     val att_sess = Attestation_Session.session_config_decompiler cc_session
+     (* ── Typeclass instances ─────────────────────────────────────── *)
      val plc_map_json =
        JSON.jsonifiable_map_serial_json
          ID_Type.coq_Stringifiable_ID_Type
@@ -248,45 +260,38 @@ structure IO_Axioms = struct
      val prreq_json =
        Interface_JSON.coq_Jsonifiable_ProtocolRunRequest
          term_json evidence_json att_sess_json
-     val Stringifiable.Build_Stringifiable js_to_str js_from_str =
+     val manifest_json =
+       Manifest_TCs.coq_Jsonifiable_Manifest
+         (JSON.jsonifiable_map_serial_json
+           ID_Type.coq_Stringifiable_ID_Type
+           ID_Type.coq_DecEq_ID_Type
+           (ID_Type.coq_Jsonifiable_ID_Type ID_Type.coq_Stringifiable_ID_Type))
+         (JSON.jsonifiable_map_serial_json
+           ID_Type.coq_Stringifiable_ID_Type
+           ID_Type.coq_DecEq_ID_Type
+           (ID_Type.coq_Jsonifiable_ID_Type ID_Type.coq_Stringifiable_ID_Type))
+     val Stringifiable.Build_Stringifiable js_to_str _ =
        JSON_Stringifiable.coq_Stringifiable_JSON
-     fun dispatch_err msg =
-       ResultMonad.Coq_err
-         (St.Coq_dispatch_error (Attestation_Session.Runtime msg))
-     (* ── Step 1: Read and parse the startup file ──────────────────── *)
-     val startup_str = Coq_TextIO.TextIO.readFile "/tmp/cvm_startup.json"
+     (* ── Build PRReq JSON object ──────────────────────────────────── *)
+     val req = Interface_Types.Coq_mkPRReq att_sess plc ev term
+     val JSON.Build_Jsonifiable prreq_to_json _ = prreq_json
+     val prreq_js = prreq_to_json req
+     (* ── Build manifest JSON object ──────────────────────────────── *)
+     val JSON.Build_Jsonifiable manifest_to_json _ = manifest_json
+     val manifest_js = manifest_to_json cc_manifest
+     (* ── Build inline bundle: {cvm_binary, manifest, asp_bin, request} *)
+     val bundle_js = JSON_Type.JSON_Object
+       (("cvm_binary", (JSON_Type.JSON_String cc_cvm_bin)) ::
+        (("manifest",  manifest_js) ::
+         (("asp_bin",  (JSON_Type.JSON_String cc_asp_bin)) ::
+          (("request", prreq_js) :: []))))
+     val bundle_str = js_to_str bundle_js
+     (* ── Non-blocking fork — returns (fd, pid) immediately ────────── *)
+     val (fd, pid) = SysFFI.c_spawn_par_process cc_cvm_bin bundle_str
+     (* ── Persist handle to temp file indexed by loc ──────────────── *)
+     val _ = par_write_handle loc fd pid
    in
-     case js_from_str startup_str of
-       ResultMonad.Coq_err e =>
-         dispatch_err ("start_par_subprocess: failed to parse startup file: " ^ e)
-     | ResultMonad.Coq_res startup_js =>
-     (* ── Step 2: Extract cvm_binary and att_sess ──────────────────── *)
-     case JSON.coq_JSON_get_string "cvm_binary" startup_js of
-       ResultMonad.Coq_err e =>
-         dispatch_err ("start_par_subprocess: missing cvm_binary in startup file: " ^ e)
-     | ResultMonad.Coq_res cvm_binary =>
-     case JSON.coq_JSON_get_Object "att_sess" startup_js of
-       ResultMonad.Coq_err e =>
-         dispatch_err ("start_par_subprocess: missing att_sess in startup file: " ^ e)
-     | ResultMonad.Coq_res att_sess_obj =>
-     let val JSON.Build_Jsonifiable _ att_sess_from_json = att_sess_json in
-     case att_sess_from_json att_sess_obj of
-       ResultMonad.Coq_err e =>
-         dispatch_err ("start_par_subprocess: failed to deserialize att_sess: " ^ e)
-     | ResultMonad.Coq_res att_sess =>
-     (* ── Step 3: Build ProtocolRunRequest ─────────────────────────── *)
-     let
-       val req = Interface_Types.Coq_mkPRReq att_sess plc ev term
-       val JSON.Build_Jsonifiable prreq_to_json _ = prreq_json
-       val req_str = js_to_str (prreq_to_json req)
-       (* ── Step 4: Non-blocking fork — returns (fd, pid) immediately ─ *)
-       val (fd, pid) = SysFFI.c_spawn_par_process cvm_binary req_str
-       (* ── Step 5: Persist handle to temp file indexed by loc ──────── *)
-       val _ = par_write_handle loc fd pid
-     in
-       ResultMonad.Coq_res ()
-     end
-     end
+     (ResultMonad.Coq_res (), st)
    end
 
  (** val collect_par_subprocess :

--- a/theories/AM_Handler.v
+++ b/theories/AM_Handler.v
@@ -63,9 +63,13 @@ Definition handle_AM_request
         end
       else tt
     in
-    let sc := session_config_compiler conf att_sess in
+    let sc  := session_config_compiler conf att_sess in
+    let cfg := mk_cvm_cfg sc
+                 (am_manager_asp_bin conf)
+                 (match cvm_binary_opt with Some b => b | None => "" end)
+                 (am_manager_manifest conf) in
     let init_st := mk_st [] 0 in
-    let '(cvm_resp, _) := build_cvm init_ev term sc init_st in
+    let '(cvm_resp, _) := build_cvm init_ev term cfg init_st in
     match cvm_resp with
     | err e => err (CVM_Error_to_string e)
     | res ev => res (to_string (to_JSON (mkPRResp true ev)))

--- a/theories/AM_Handler.v
+++ b/theories/AM_Handler.v
@@ -48,14 +48,13 @@ Definition handle_AM_request
   if (dec_eq action_str STR_RUN) then
     (* Run the protocol *)
     '(mkPRReq att_sess req_plc init_ev term) <- from_JSON jsreq ;;
-    (* If the term contains bpar, write the startup file so that
-       parallel_vm_thread can launch a subprocess CVM instance. *)
+    (* Warn if the term contains bpar but no cvm_binary was provided.
+       The CVM_Config monad reader carries cvm_binary to start_par_subprocess;
+       no startup file is written (Option B). *)
     let _ :=
       if term_has_bpar term then
         match cvm_binary_opt with
-        | Some cvm_bin =>
-          TextIO.writeFile CVM_STARTUP_FILE
-            (to_string (build_startup_json conf att_sess cvm_bin))
+        | Some _ => tt
         | None =>
           TextIO.printLn_err
             "WARNING: term contains bpar but --cvm_binary was not provided; \

--- a/theories/AM_Handler.v
+++ b/theories/AM_Handler.v
@@ -3,15 +3,66 @@ From RocqJSON Require Import JSON.
 From CoplandSpec Require Import System_Types Interface.Interface.
 From CoplandManifestTools Require Import Manifest.
 From CVM Require Import Impl St Session_Config_Compiler AM_Manager.
+From EasyBakeCakeML Require Import CakeML_Stdlib.All.
 
-(* Processes the request given by [reqstr] and returns a string (json response) value *)
-Definition handle_AM_request (conf : AM_Manager_Config) (reqstr : string) 
+Local Open Scope string_scope.
+
+(* Returns true if the term contains a bpar node anywhere in its structure *)
+Fixpoint term_has_bpar (t : Term) : bool :=
+  match t with
+  | asp _           => false
+  | att _ t'        => term_has_bpar t'
+  | lseq t1 t2      => orb (term_has_bpar t1) (term_has_bpar t2)
+  | bseq _ t1 t2    => orb (term_has_bpar t1) (term_has_bpar t2)
+  | bpar _ _ _      => true
+  end.
+
+(* CVM startup file path written before bpar execution begins.
+   The parallel_vm_thread stub reads this to locate the CVM binary and
+   session configuration needed to launch a subprocess CVM instance. *)
+Definition CVM_STARTUP_FILE : string := "/tmp/cvm_startup.json".
+
+(* Build the startup JSON containing all configuration a subprocess CVM
+   needs: the binary path, manifest, ASP binary directory, and att_sess. *)
+Definition build_startup_json
+    (conf : AM_Manager_Config)
+    (att_sess : Attestation_Session)
+    (cvm_bin : string) : JSON :=
+  JSON_Object [
+    ("cvm_binary",  JSON_String cvm_bin);
+    ("manifest",    to_JSON (am_manager_manifest conf));
+    ("asp_bin",     JSON_String (am_manager_asp_bin conf));
+    ("att_sess",    to_JSON att_sess)
+  ].
+
+(* Processes the request given by [reqstr] and returns a string (json response) value.
+   [cvm_binary_opt] is the path to the CVM binary used to spawn parallel subprocess
+   instances when the term contains a bpar node. *)
+Definition handle_AM_request
+    (conf : AM_Manager_Config)
+    (cvm_binary_opt : option string)
+    (reqstr : string)
     : Result string string :=
   jsreq <- from_string reqstr ;;
   action_str <- JSON_get_string STR_ACTION jsreq ;;
   if (dec_eq action_str STR_RUN) then
     (* Run the protocol *)
     '(mkPRReq att_sess req_plc init_ev term) <- from_JSON jsreq ;;
+    (* If the term contains bpar, write the startup file so that
+       parallel_vm_thread can launch a subprocess CVM instance. *)
+    let _ :=
+      if term_has_bpar term then
+        match cvm_binary_opt with
+        | Some cvm_bin =>
+          TextIO.writeFile CVM_STARTUP_FILE
+            (to_string (build_startup_json conf att_sess cvm_bin))
+        | None =>
+          TextIO.printLn_err
+            "WARNING: term contains bpar but --cvm_binary was not provided; \
+             parallel branches will return an error."
+        end
+      else tt
+    in
     let sc := session_config_compiler conf att_sess in
     let init_st := mk_st [] 0 in
     let '(cvm_resp, _) := build_cvm init_ev term sc init_st in
@@ -24,3 +75,5 @@ Definition handle_AM_request (conf : AM_Manager_Config) (reqstr : string)
   else if (dec_eq action_str STR_APPSUMM) then
     err "App summary action not implemented yet"
   else err ("Invalid request action: " ++ action_str).
+
+Local Close Scope string_scope.

--- a/theories/Cvm_Axioms.v
+++ b/theories/Cvm_Axioms.v
@@ -9,16 +9,8 @@ Axiom parallel_vm_thread_axiom : forall i t e p res,
     session_plc (cc_session sc) = p ->
     exists st', build_cvm e t sc st = (res, st').
 
-Axiom start_par_subprocess_axiom : forall i p e t, 
-start_par_subprocess i p e t = res tt.
-(*
-    Definition start_par_subprocess (loc:Loc) (p:Plc) (e:Evidence) (t:Term)
-    : Result unit CVM_Error. Admitted.
-*)
-(*
-Definition collect_par_subprocess (loc:Loc) (p:Plc) (e:Evidence) (t:Term)
-    : Result Evidence CVM_Error. Admitted.
-*)
+Axiom start_par_subprocess_axiom : forall i p e t,
+  start_par_subprocess i p e t = CVM_ret tt.
 
 Axiom do_remote_res_axiom : forall (cfg : CVM_Config) p e t res,
   do_remote (cc_session cfg) p e t = res ->

--- a/theories/Cvm_Axioms.v
+++ b/theories/Cvm_Axioms.v
@@ -3,11 +3,22 @@ From CoplandSpec Require Import Attestation_Session.
 From CVM Require Import IO_Utils Monad Impl.
 
 Axiom parallel_vm_thread_axiom : forall i t e p res,
-  parallel_vm_thread i p e t = res ->
+  (* parallel_vm_thread *) collect_par_subprocess i p e t = res ->
   forall st sc,
     st = {| st_trace := nil; st_evid := i |} ->
     session_plc sc = p ->
     exists st', build_cvm e t sc st = (res, st').
+
+Axiom start_par_subprocess_axiom : forall i p e t, 
+start_par_subprocess i p e t = res tt.
+(*
+    Definition start_par_subprocess (loc:Loc) (p:Plc) (e:Evidence) (t:Term)
+    : Result unit CVM_Error. Admitted.
+*)
+(*
+Definition collect_par_subprocess (loc:Loc) (p:Plc) (e:Evidence) (t:Term)
+    : Result Evidence CVM_Error. Admitted.
+*)
 
 Axiom do_remote_res_axiom : forall sc p e t res,
   do_remote sc p e t = res ->

--- a/theories/Cvm_Axioms.v
+++ b/theories/Cvm_Axioms.v
@@ -4,9 +4,9 @@ From CVM Require Import IO_Utils Monad Impl.
 
 Axiom parallel_vm_thread_axiom : forall i t e p res,
   (* parallel_vm_thread *) collect_par_subprocess i p e t = res ->
-  forall st sc,
+  forall st (sc : CVM_Config),
     st = {| st_trace := nil; st_evid := i |} ->
-    session_plc sc = p ->
+    session_plc (cc_session sc) = p ->
     exists st', build_cvm e t sc st = (res, st').
 
 Axiom start_par_subprocess_axiom : forall i p e t, 
@@ -20,14 +20,11 @@ Definition collect_par_subprocess (loc:Loc) (p:Plc) (e:Evidence) (t:Term)
     : Result Evidence CVM_Error. Admitted.
 *)
 
-Axiom do_remote_res_axiom : forall sc p e t res,
-  do_remote sc p e t = res ->
-  forall st sc' i,
-    (* NOTE: This is maybe a bit stronger than we want!
-    we really need to be looking at the NEW session config that was
-    created via the passed session *)
+Axiom do_remote_res_axiom : forall (cfg : CVM_Config) p e t res,
+  do_remote (cc_session cfg) p e t = res ->
+  forall st i,
     st = {| st_trace := nil; st_evid := i |} ->
-    exists st',
-      build_cvm e t sc st = (res, st') /\
-      session_plc sc' = p /\
-      session_context sc' = session_context sc.
+    exists (cfg' : CVM_Config) st',
+      build_cvm e t cfg' st = (res, st') /\
+      session_plc (cc_session cfg') = p /\
+      session_context (cc_session cfg') = session_context (cc_session cfg).

--- a/theories/FrontEnd.v
+++ b/theories/FrontEnd.v
@@ -156,20 +156,22 @@ Definition cvm_front_end : unit :=
    * ------------------------------------------------------------------ *)
   match comargs with
   | [] =>
-    (* Stdin mode: the subprocess CVM reads its session config from the
-       startup file written by the parent, then reads the actual
-       ProtocolRunRequest JSON from stdin.  This keeps the request format
-       identical to the normal CLI mode; only the config source changes. *)
-    let startup_str := TextIO.readFile AM_Handler.CVM_STARTUP_FILE in
-    let req_str     := read_all_stdin in
+    (* Stdin mode: the subprocess CVM receives a single inline bundle JSON
+       on stdin, containing all config it needs plus the ProtocolRunRequest.
+       Format: { "cvm_binary": "...", "manifest": {...}, "asp_bin": "...",
+                 "request": { <PRReq JSON object> } }
+       No startup file is read; everything comes from the bundle. *)
+    let bundle_str := read_all_stdin in
     let runtime : Result string string := (
-      startup_js   <- from_string startup_str ;;
-      manifest_js  <- JSON_get_Object "manifest"   startup_js ;;
-      asp_bin_val  <- JSON_get_string "asp_bin"    startup_js ;;
-      cvm_bin_str  <- JSON_get_string "cvm_binary" startup_js ;;
+      bundle_js    <- from_string bundle_str ;;
+      manifest_js  <- JSON_get_Object "manifest"   bundle_js ;;
+      asp_bin_val  <- JSON_get_string "asp_bin"    bundle_js ;;
+      cvm_bin_str  <- JSON_get_string "cvm_binary" bundle_js ;;
+      req_js       <- JSON_get_Object "request"    bundle_js ;;
       manifest_val <- from_JSON manifest_js ;;
       let am_manager_conf := mkAM_Man_Conf manifest_val asp_bin_val in
       let cvm_binary_opt  := Some cvm_bin_str in
+      let req_str         := to_string req_js in
       handle_AM_request am_manager_conf cvm_binary_opt req_str
     ) in
     match runtime with

--- a/theories/FrontEnd.v
+++ b/theories/FrontEnd.v
@@ -2,6 +2,7 @@ From CVM Require Import Impl Session_Config_Compiler AM_Handler AM_Manager.
 From CoplandManifestTools Require Import Manifest.
 From CLITools Require Import CLI_Tools.
 From RocqLogging Require Import Logging.
+From RocqJSON Require Import JSON.
 From EasyBakeCakeML Require Import
   EasyBakeCakeML
   ExtrCakeMLNativeString
@@ -74,6 +75,14 @@ Definition request_file_arg_spec : arg_spec := {|
   arg_default := None
 |}.
 
+Definition cvm_binary_arg_spec : arg_spec := {|
+  arg_name := "cvm_binary";
+  arg_kind := ArgOption;
+  arg_required := false;
+  arg_help := "Path to this CVM binary, used to spawn subprocess CVM instances for parallel (bpar) terms.";
+  arg_default := None
+|}.
+
 (*
 Inductive LogLevel : Type :=
 | Debug
@@ -124,13 +133,55 @@ Definition unwrap_opt {A B} (opt: option A) (alt : B) : Result A B :=
   | None => err alt
   end.
 
+(* Shim for reading all of stdin.  CakeML's TextIO.stdIn is not modeled
+   in EasyBakeCakeML, so we introduce it here as an inlined extraction
+   constant and build read_all_stdin from it. *)
+Definition stdin_stream : TextIO.instream. Admitted.
+Extract Inlined Constant stdin_stream => "TextIO.stdIn".
+
+Definition read_all_stdin : string := TextIO.inputAll stdin_stream.
+
 Local Open Scope map_scope.
 
-Definition cvm_front_end : unit := 
+Definition cvm_front_end : unit :=
   let comname := CommandLine.name tt in
   let comargs := CommandLine.arguments tt in
-  let args_spec := 
-    [log_level_arg_spec; manifest_arg_spec; manifest_file_arg_spec; asp_bin_arg_spec; request_arg_spec; request_file_arg_spec] in
+  (* ------------------------------------------------------------------ *
+   * Stdin mode: when the process is invoked with no CLI arguments (e.g.
+   * as a subprocess CVM for a bpar branch), the full ProtocolRunRequest
+   * JSON blob is read from stdin.  The manifest, asp_bin, and
+   * cvm_binary fields are embedded directly in that JSON blob (written
+   * by the parent CVM's handle_AM_request via the startup file, and
+   * reconstructed by parallel_vm_thread before exec).
+   * ------------------------------------------------------------------ *)
+  match comargs with
+  | [] =>
+    (* Stdin mode: the subprocess CVM reads its session config from the
+       startup file written by the parent, then reads the actual
+       ProtocolRunRequest JSON from stdin.  This keeps the request format
+       identical to the normal CLI mode; only the config source changes. *)
+    let startup_str := TextIO.readFile AM_Handler.CVM_STARTUP_FILE in
+    let req_str     := read_all_stdin in
+    let runtime : Result string string := (
+      startup_js   <- from_string startup_str ;;
+      manifest_js  <- JSON_get_Object "manifest"   startup_js ;;
+      asp_bin_val  <- JSON_get_string "asp_bin"    startup_js ;;
+      cvm_bin_str  <- JSON_get_string "cvm_binary" startup_js ;;
+      manifest_val <- from_JSON manifest_js ;;
+      let am_manager_conf := mkAM_Man_Conf manifest_val asp_bin_val in
+      let cvm_binary_opt  := Some cvm_bin_str in
+      handle_AM_request am_manager_conf cvm_binary_opt req_str
+    ) in
+    match runtime with
+    | res resp_str => TextIO.printLn resp_str
+    | err e => TextIO.printLn_err ("Error in CVM Execution (stdin mode): " ++ e)
+    end
+  | _ =>
+  (* Normal CLI mode *)
+  let args_spec :=
+    [log_level_arg_spec; manifest_arg_spec; manifest_file_arg_spec;
+     asp_bin_arg_spec; request_arg_spec; request_file_arg_spec;
+     cvm_binary_arg_spec] in
   let runtime := (
     args_res <- gather_args_stub comname comargs args_spec ;;
     (* let _ := log Debug Debug (to_string args_res) in *)
@@ -148,10 +199,10 @@ Definition cvm_front_end : unit :=
     manifest_val <-
       match arg_found manifest_arg, arg_found manifest_file_arg with
       | true, true => err "Both manifest and manifest_file arguments were provided. Please provide only one."
-      | true, false => 
+      | true, false =>
         arg_val <- unwrap_opt (arg_value manifest_arg) "Manifest argument value was not found." ;;
         from_string arg_val
-      | false, true => 
+      | false, true =>
         arg_val <- unwrap_opt (arg_value manifest_file_arg) "Manifest file argument value was not found." ;;
         (* Read the file content if manifest_file is provided *)
         (* NOTE: This should probably be exception catching, but not done yet! *)
@@ -168,38 +219,44 @@ Definition cvm_front_end : unit :=
     _ <- debug_log ("ASP binary value: " ++ asp_bin_val) ;;
     (* Parse the manifest *)
     let am_manager_conf := (mkAM_Man_Conf manifest_val asp_bin_val) in
+    (* Extract the optional cvm_binary argument *)
+    let cvm_binary_opt :=
+      match args_res ![ "cvm_binary" ] with
+      | Some arg => arg_value arg
+      | None => None
+      end
+    in
     (* Getting the request argument *)
     _ <- debug_log "Parsing request arguments." ;;
     request_arg <- unwrap_opt (args_res ![ "req" ]) "Request argument is required." ;;
     request_file_arg <- unwrap_opt (args_res ![ "req_file" ]) "Request file argument is required." ;;
-    request_val <- 
+    request_str <-
       match arg_found request_arg, arg_found request_file_arg with
       | true, true => err "Both req and req_file arguments were provided. Please provide only one."
-      | true, false => 
+      | true, false =>
         _ <- debug_log "Using request argument value." ;;
-        (* If req is provided, parse it *)
+        (* If req is provided, use it directly *)
         arg_val <- unwrap_opt (arg_value request_arg) "Request argument value was not found." ;;
         _ <- debug_log ("Request argument value: " ++ arg_val) ;;
-        from_string arg_val
-      | false, true => 
+        res arg_val
+      | false, true =>
         _ <- debug_log "Using request file argument value." ;;
         (* If req_file is provided, read the file content *)
         arg_val <- unwrap_opt (arg_value request_file_arg) "Request file argument value was not found." ;;
         _ <- debug_log ("Request file argument value: " ++ arg_val) ;;
         (* NOTE: This should probably be exception catching, but not done yet! *)
-        (* Read the file content if req_file is provided *)
         let str_val := TextIO.readFile arg_val in
         _ <- debug_log ("Request file content: " ++ str_val) ;;
-        (* Convert the string to JSON *)
-        from_string str_val
+        res str_val
       | false, false => err "Request argument is required. Please provide either --req or --req_file."
       end ;;
     (* Actually process the request *)
-    handle_AM_request am_manager_conf request_val
+    handle_AM_request am_manager_conf cvm_binary_opt request_str
   ) in
   match runtime with
   | res resp_str => TextIO.printLn resp_str
   | err e => TextIO.printLn_err ("Error in CVM Execution: " ++ e)
+  end
   end.
 
 Local Close Scope map_scope.

--- a/theories/IO_Axioms.v
+++ b/theories/IO_Axioms.v
@@ -21,5 +21,23 @@ Definition make_fs_request (path : FS_Location) (str : string) : Result string s
 
 Definition aspid_to_fs_location (aspid : ASP_ID) : FS_Location. Admitted.
 
-(** * Stub to simulate EvidenceT collected by a parallel CVM instance *)
+(** * Stub to simulate EvidenceT collected by a parallel CVM instance.
+    Used by Phase 1 (sequential subprocess).  Superseded by the split
+    start/collect pair below for Phase 2 (true parallel). *)
 Definition parallel_vm_thread (l:Loc) (p:Plc) (e:Evidence) (t: Term) : Result Evidence CVM_Error.  Admitted.
+
+(** * Phase 2 split-subprocess primitives.
+
+    [start_par_subprocess] forks a subprocess CVM for term [t] (with evidence
+    [e] at place [p]), writes the serialised ProtocolRunRequest to its stdin,
+    and returns immediately.  The OS-level pipe fd and PID are stored in a
+    CML-side global table indexed by [loc] so that [collect_par_subprocess]
+    can retrieve them.
+
+    [collect_par_subprocess] blocks until the subprocess launched at [loc]
+    exits, reads its stdout, and deserialises the returned Evidence. *)
+Definition start_par_subprocess (loc:Loc) (p:Plc) (e:Evidence) (t:Term)
+    : Result unit CVM_Error. Admitted.
+
+Definition collect_par_subprocess (loc:Loc) (p:Plc) (e:Evidence) (t:Term)
+    : Result Evidence CVM_Error. Admitted.

--- a/theories/IO_Axioms.v
+++ b/theories/IO_Axioms.v
@@ -37,7 +37,7 @@ Definition parallel_vm_thread (l:Loc) (p:Plc) (e:Evidence) (t: Term) : Result Ev
     [collect_par_subprocess] blocks until the subprocess launched at [loc]
     exits, reads its stdout, and deserialises the returned Evidence. *)
 Definition start_par_subprocess (loc:Loc) (p:Plc) (e:Evidence) (t:Term)
-    : Result unit CVM_Error. Admitted.
+    : CVM unit. Admitted.
 
 Definition collect_par_subprocess (loc:Loc) (p:Plc) (e:Evidence) (t:Term)
     : Result Evidence CVM_Error. Admitted.

--- a/theories/IO_Utils.v
+++ b/theories/IO_Utils.v
@@ -28,7 +28,5 @@ Definition make_JSON_FS_Location_Request (dir : FS_Location) (aspid : FS_Locatio
   from_string resstr.
 
 Definition do_start_par_thread (loc:Loc) (p:Plc) (e: Evidence) (t: Term) : CVM unit :=
-  match start_par_subprocess loc p e t with
-  | res tt => CVM_ret tt
-  | err s  => CVM_fail s
-  end.
+  start_par_subprocess loc p e t.
+Hint Unfold do_start_par_thread : cvm.

--- a/theories/IO_Utils.v
+++ b/theories/IO_Utils.v
@@ -27,5 +27,8 @@ Definition make_JSON_FS_Location_Request (dir : FS_Location) (aspid : FS_Locatio
   resstr <- make_fs_request (fs_location_join dir aspid) (to_string js) ;;
   from_string resstr.
 
-Definition do_start_par_thread (loc:Loc) (e: Evidence) (t: Term) : CVM unit :=
-  CVM_ret tt.
+Definition do_start_par_thread (loc:Loc) (p:Plc) (e: Evidence) (t: Term) : CVM unit :=
+  match start_par_subprocess loc p e t with
+  | res tt => CVM_ret tt
+  | err s  => CVM_fail s
+  end.

--- a/theories/Monad.v
+++ b/theories/Monad.v
@@ -14,8 +14,12 @@ Definition get_st : CVM cvm_st :=
 Hint Unfold get_st : cvm.
 
 Definition get_config : CVM Session_Config :=
-  CVM_ask.
+  CVM_ask_session.
 Hint Unfold get_config : cvm.
+
+Definition get_cvm_config : CVM CVM_Config :=
+  CVM_ask.
+Hint Unfold get_cvm_config : cvm.
 
 Definition get_trace : CVM (list Ev) :=
   st <- get_st ;;cvm

--- a/theories/Monad.v
+++ b/theories/Monad.v
@@ -425,13 +425,13 @@ Definition start_par_thread (e:Evidence) (t: Term) : CVM nat :=
   p <- get_pl ;;cvm
   i <- inc_id ;;cvm
   (* The loc always = the event id for the thread_start event *)
-  do_start_par_thread i e t ;;cvm
+  do_start_par_thread i p e t ;;cvm
   add_trace [cvm_thread_start i i p (get_et e) t] ;;cvm
   CVM_ret i.
 Hint Unfold start_par_thread : cvm.
 
 Definition do_wait_par_thread (loc:Loc) (p:Plc) (e:Evidence) (t: Term) : CVM Evidence :=
-  match (parallel_vm_thread loc p e t) with
+  match (collect_par_subprocess loc p e t) with
   | res e' => CVM_ret e'
   | err s => CVM_fail s
   end.

--- a/theories/St.v
+++ b/theories/St.v
@@ -7,6 +7,7 @@ Author:  Adam Petz, ampetz@ku.edu
 *)
 From RocqCandy Require Import All.
 From CoplandSpec Require Export Term_Defs Attestation_Session.
+From CoplandManifestTools Require Import Manifest.
 
 (** CVM monad state structure.
 
@@ -45,8 +46,18 @@ Definition CVM_Error_to_string (e : CVM_Error) : string :=
   end.
 Opaque CVM_Error_to_string.
 
-Definition CVM A : Type := 
-  Config Session_Config (State cvm_st (Result A CVM_Error)).
+(** Runtime configuration threaded read-only through the CVM monad.
+    Extends Session_Config with the paths/data needed to spawn subprocess
+    CVM instances for bpar terms, eliminating the shared startup file. *)
+Record CVM_Config : Type := mk_cvm_cfg {
+  cc_session  : Session_Config ;
+  cc_asp_bin  : string ;
+  cc_cvm_bin  : string ;
+  cc_manifest : Manifest ;
+}.
+
+Definition CVM A : Type :=
+  Config CVM_Config (State cvm_st (Result A CVM_Error)).
 
 Global Create HintDb cvm.
 
@@ -62,14 +73,19 @@ Definition CVM_ret {A} (a : A) : CVM A :=
   fun _ st => (res a, st).
 Definition CVM_fail {A} (e : CVM_Error) : CVM A :=
   fun _ st => (err e, st).
-Definition CVM_ask : CVM Session_Config :=
+Definition CVM_ask : CVM CVM_Config :=
   fun conf st => (res conf, st).
+(** Project only the Session_Config out of the CVM reader environment.
+    Use this everywhere the old CVM_ask was used to avoid touching every
+    call-site while the CVM_Config record is being introduced. *)
+Definition CVM_ask_session : CVM Session_Config :=
+  fun conf st => (res (cc_session conf), st).
 Definition CVM_put (st : cvm_st) : CVM unit :=
   fun _ _ => (res tt, st).
 Definition CVM_get : CVM cvm_st :=
   fun _ st => (res st, st).
 
-Global Hint Unfold CVM_bind CVM_ret CVM_ask CVM_put CVM_get CVM_fail : cvm.
+Global Hint Unfold CVM_bind CVM_ret CVM_ask CVM_ask_session CVM_put CVM_get CVM_fail : cvm.
 
 Notation "x <- m ;;cvm c" := (CVM_bind m (fun x => c))
   (at level 61, m at next level, right associativity).

--- a/theories/Verification.v
+++ b/theories/Verification.v
@@ -17,6 +17,7 @@
 From RocqCandy Require Import All.
 From CoplandSpec Require Import Term_Defs Event_System Attestation_Session.
 From CVM Require Import Impl St Monad Cvm_Axioms.
+Require Import Cvm_Axioms.
 Local Open Scope list_scope.
 
 Lemma peel_n_rawev_result_spec : forall n ls ls1 ls2,
@@ -201,7 +202,12 @@ Proof.
       eapply $ihv in $h1 > [ | | eapply $h2v ]; ff;
       try (clear $ih $h2)
   end);
-  try (  solve [ eapply invoke_APPR_deterministic; ff ]).
+
+  try (  solve [ eapply invoke_APPR_deterministic; ff ]);
+
+  try (unfold do_start_par_thread in *);
+  try (unfold start_par_subprocess in *);
+  repeat ((rewrite start_par_subprocess_axiom in *); ff; cvm_monad_unfold; ff).
 Qed.
 
 Lemma appr_events'_errs_deterministic : forall G p e e' i1 e1,
@@ -297,7 +303,9 @@ Proof.
     end)).
   - ff; try (
     repeat (match! goal with
-    | [ h : parallel_vm_thread _ _ _ _ = ?_res |- _ ] =>
+    | [ h : collect_par_subprocess _ _ _ _ = ?_res |- _ ] =>
+      try (unfold do_start_par_thread in *);
+      try (unfold start_par_subprocess in *);
       eapply parallel_vm_thread_axiom in $h; ff
     | [ h1 : build_cvm _ ?_t _ _ = _,
         h2 : build_cvm _ ?_t _ _ = _,
@@ -313,7 +321,10 @@ Proof.
       let h2 := Control.hyp h2 in
       try (eapply events_fix_only_one_error in $h1; try (eapply $h2); ff; try eauto; fail);
       try (eapply events_fix_errs_deterministic in $h1; try (eapply $h2); ff; try eauto; fail)
-    end); fail).
+    end); fail);
+      try (unfold do_start_par_thread in *);
+  try (unfold start_par_subprocess in *);
+  repeat ((rewrite start_par_subprocess_axiom in *); ff; cvm_monad_unfold; ff).
 Qed.
 
 Lemma invoke_APPR'_spans : forall G' et r e' sc c i st eo,
@@ -783,7 +794,10 @@ Proof.
     find_eapply_lem_hyp IHt2; ff with l.
   - ff with u, a, (cvm_monad_unfold).
     destruct e;
-    find_eapply_lem_hyp IHt1; ff with l.
+    find_eapply_lem_hyp IHt1; ff with l;
+      try (unfold do_start_par_thread in *);
+  try (unfold start_par_subprocess in *);
+  repeat ((rewrite start_par_subprocess_axiom in *); ff; cvm_monad_unfold; ff); lia.
 Qed.
 
 Lemma wf_Evidence_split : forall G r1 r2 et1 et2,
@@ -996,9 +1010,12 @@ Proof.
     eapply IHt1 in Heq > [ | eapply wf_Evidence_proc_left; ff ].
     eapply IHt2 in Heq0 > [ | eapply wf_Evidence_proc_right; ff ].
     ff; eauto with wf_Evidence.
-  - ff; simpl in *.
+  - ff; simpl in *;
+    try (unfold do_start_par_thread in *);
+  try (unfold start_par_subprocess in *);
+  repeat ((rewrite start_par_subprocess_axiom in *); ff; cvm_monad_unfold; ff).
     find_eapply_lem_hyp parallel_vm_thread_axiom; ff.
-    eapply IHt1 in Heq > [ | eapply wf_Evidence_proc_left; ff ].
+    eapply IHt1 in Heq1 > [ | eapply wf_Evidence_proc_left; ff ].
     destruct e;
     ff; eauto with wf_Evidence.
 
@@ -1187,11 +1204,21 @@ Proof.
     eapply events_range; eauto; ff with a).
   - destruct e; Control.enter (fun () =>
     ff with a; invc H0; ff with a;
+    (* Phase 2: expose start_par_subprocess via first cvm_monad_unfold,
+       then rewrite it to res tt before ff does a case split on it.
+       This ensures Heq = build_cvm t1 hypothesis (not start_par_subprocess). *)
+    cvm_monad_unfold;
+    repeat (
+    try (rewrite start_par_subprocess_axiom in *);
     cvm_monad_unfold; ff with a;
+    try (find_eapply_lem_hyp parallel_vm_thread_axiom);
+    try (unfold do_start_par_thread in *);
+
+        try (find_eapply_lem_hyp start_par_subprocess_axiom);
     simpl in *; repeat find_rewrite;
-    repeat find_injection; ff;
-    eapply IHt1 in Heq as ?; eauto; ff; try lia;
-    eapply cvm_spans in Heq as ?; eauto; ff;
+    repeat (find_injection; ff)));
+    eapply IHt1 in Heq1 as ?; eauto; ff; try lia;
+    eapply cvm_spans in Heq1 as ?; eauto; ff;
     try (repeat find_rewrite; simpl in *;
       eapply events_range; eauto; ff; fail);
     repeat find_rewrite; try lia;
@@ -1202,7 +1229,7 @@ Proof.
     erewrite events_events_fix_eq in *; ff;
     assert (n = List.length evs2) by (
       repeat (find_eapply_lem_hyp events_fix_range); eauto; ff);
-    ff).
+    ff.
 Qed.
 
 Corollary cvm_trace_respects_events_default : forall G,

--- a/theories/Verification.v
+++ b/theories/Verification.v
@@ -35,7 +35,7 @@ Proof.
 Qed.
 
 Lemma invoke_APPR_deterministic : forall G e sc st1 st2 st1' st2' res1 res2 r oe,
-  G = session_context sc ->
+  G = session_context (cc_session sc) ->
   st_evid st1 = st_evid st2 ->
   invoke_APPR' r e oe sc st1 = (res1, st1') ->
   invoke_APPR' r e oe sc st2 = (res2, st2') ->
@@ -105,7 +105,7 @@ Proof.
 Qed.
 
 Theorem invoke_APPR_deterministic_Evidence : forall G et st1 st2 r1 r2 st1' st2' r sc eo,
-  G = session_context sc ->
+  G = session_context (cc_session sc) ->
   invoke_APPR' r et eo sc st1 = (r1, st1') ->
   invoke_APPR' r et eo sc st2 = (r2, st2') ->
   r1 = r2.
@@ -328,10 +328,10 @@ Proof.
 Qed.
 
 Lemma invoke_APPR'_spans : forall G' et r e' sc c i st eo,
-  G' = session_context sc ->
+  G' = session_context (cc_session sc) ->
   invoke_APPR' r et eo sc st = (res e', c) ->
   forall G,
-  G = session_context sc ->
+  G = session_context (cc_session sc) ->
   appr_events_size G et = res i ->
   st_evid c = st_evid st + i.
 Proof.
@@ -677,15 +677,15 @@ Definition well_formed_context (G : GlobalContext) : Prop :=
 
 Lemma invoke_ASP_evidence : forall e par st sc e' st',
   invoke_ASP e par sc st = (res e', st') ->
-  get_et e' = asp_evt (session_plc sc) par (get_et e).
+  get_et e' = asp_evt (session_plc (cc_session sc)) par (get_et e).
 Proof.
   cvm_monad_unfold; ff.
 Qed.
 
 Theorem invoke_APPR'_evidence : forall G et st r sc st' e' e eo,
-  G = session_context sc ->
+  G = session_context (cc_session sc) ->
   invoke_APPR' r et eo sc st = (res e', st') ->
-  appr_procedure' (session_context sc) (session_plc sc) et eo = res e ->
+  appr_procedure' (session_context (cc_session sc)) (session_plc (cc_session sc)) et eo = res e ->
   get_et e' = e.
 Proof.
   intros G.
@@ -726,7 +726,7 @@ Qed.
 
 Theorem cvm_evidence_type : forall t e e' st st' sc et',
   build_cvm e t sc st = (res e', st') ->
-  eval (session_context sc) (session_plc sc) (get_et e) t = res et' ->
+  eval (session_context (cc_session sc)) (session_plc (cc_session sc)) (get_et e) t = res et' ->
   get_et e' = et'.
 Proof.
   induction t; simpl in *; intuition.
@@ -764,9 +764,9 @@ Qed.
 
 (** * Lemma:  CVM increases event IDs according to event_id_span' denotation. *)
 Lemma cvm_spans: forall t st e st' sc i e',
-  well_formed_context (session_context sc) ->
+  well_formed_context (session_context (cc_session sc)) ->
   build_cvm e t sc st = (res e', st') ->
-  events_size (session_context sc) (session_plc sc) (get_et e) t = res i ->
+  events_size (session_context (cc_session sc)) (session_plc (cc_session sc)) (get_et e) t = res i ->
   st_evid st' = st_evid st + i.
 Proof.
   induction t; simpl in *; intuition.
@@ -884,11 +884,11 @@ Proof.
 Qed.
 
 Lemma wf_Evidence_invoke_APPR : forall G et r eo st e' st' sc,
-  G = session_context sc ->
-  wf_Evidence (session_context sc) (evc r et) ->
-  wf_Evidence (session_context sc) (evc r eo) ->
+  G = session_context (cc_session sc) ->
+  wf_Evidence (session_context (cc_session sc)) (evc r et) ->
+  wf_Evidence (session_context (cc_session sc)) (evc r eo) ->
   invoke_APPR' r et eo sc st = (res e', st') ->
-  wf_Evidence (session_context sc) e'.
+  wf_Evidence (session_context (cc_session sc)) e'.
 Proof.
   intros G.
   induction et using (Evidence_subterm_path_Ind_special G); intuition.
@@ -981,9 +981,9 @@ Qed.
 (** * Theorem:  CVM execution preserves well-formedness of Evidence bundles 
       (EvidenceT Type of sufficient length for raw EvidenceT). *)
 Theorem cvm_preserves_wf_Evidence : forall t st st' e e' sc,
-  wf_Evidence (session_context sc) e ->
+  wf_Evidence (session_context (cc_session sc)) e ->
   build_cvm e t sc st = (res e', st') ->
-  wf_Evidence (session_context sc) e'.
+  wf_Evidence (session_context (cc_session sc)) e'.
 Proof.
   induction t; simpl in *; intros; cvm_monad_unfold.
   - ff;
@@ -1002,9 +1002,9 @@ Proof.
       f_equal; lia).
     eapply wf_Evidence_invoke_APPR; eauto; destruct e; ff.
   - ff;
-    find_eapply_lem_hyp do_remote_res_axiom; eauto; ff.
-    Unshelve. 
-    eapply 0.
+    find_eapply_lem_hyp do_remote_res_axiom; ff; eauto; ff.
+    find_eapply_lem_hyp IHt; ff.
+    Unshelve. eapply 0.
   - ff.
   - ff; simpl in *.
     eapply IHt1 in Heq > [ | eapply wf_Evidence_proc_left; ff ].
@@ -1025,12 +1025,12 @@ Proof.
 Qed.
 
 Theorem invoke_APPR_respects_events : forall G et r eo st sc st' e' i m evs,
-  G = session_context sc ->
-  well_formed_context (session_context sc) ->
+  G = session_context (cc_session sc) ->
+  well_formed_context (session_context (cc_session sc)) ->
   st_evid st = i ->
   st_trace st = m ->
   invoke_APPR' r et eo sc st = (res e', st') ->
-  appr_events' (session_context sc) (session_plc sc) et eo i = res evs ->
+  appr_events' (session_context (cc_session sc)) (session_plc (cc_session sc)) et eo i = res evs ->
   st_trace st' = m ++ evs.
 Proof.
   intros G.
@@ -1134,11 +1134,11 @@ Qed.
 (** * Main Theorem: CVM traces are respected the reference "events"
       semantics. *)
 Theorem cvm_trace_respects_events : forall t st m st' i p e evs sc e',
-  well_formed_context (session_context sc) ->
-  events (session_context sc) (cop_phrase p (get_et e) t) i evs ->
+  well_formed_context (session_context (cc_session sc)) ->
+  events (session_context (cc_session sc)) (cop_phrase p (get_et e) t) i evs ->
   st_trace st = m ->
   st_evid st = i ->
-  session_plc sc = p ->
+  session_plc (cc_session sc) = p ->
   build_cvm e t sc st = (res e', st') ->
   st_trace st' = m ++ evs.
 Proof.
@@ -1242,8 +1242,8 @@ Corollary cvm_trace_respects_events_default : forall G,
   forall t st st' i p e evs sc e',
   st_trace st = nil ->
   st_evid st = i ->
-  session_plc sc = p ->
-  session_context sc = G ->
+  session_plc (cc_session sc) = p ->
+  session_context (cc_session sc) = G ->
   events G (cop_phrase p (get_et e) t) i evs ->
 
   build_cvm e t sc st = (res e', st') ->

--- a/theories/Verification.v
+++ b/theories/Verification.v
@@ -1204,21 +1204,26 @@ Proof.
     eapply events_range; eauto; ff with a).
   - destruct e; Control.enter (fun () =>
     ff with a; invc H0; ff with a;
-    (* Phase 2: expose start_par_subprocess via first cvm_monad_unfold,
-       then rewrite it to res tt before ff does a case split on it.
-       This ensures Heq = build_cvm t1 hypothesis (not start_par_subprocess). *)
+    (* Phase 2: normalize start_par_subprocess → res tt before ff sees it,
+       keeping parallel_vm_thread_axiom (for collect_par_subprocess / t2)
+       out of the loop so only one build_cvm hypothesis exists when we
+       apply IHt1.  We then find that hypothesis dynamically via match!. *)
     cvm_monad_unfold;
     repeat (
-    try (rewrite start_par_subprocess_axiom in *);
-    cvm_monad_unfold; ff with a;
+      try (rewrite start_par_subprocess_axiom in *);
+      cvm_monad_unfold; ff with a;
+      try (unfold do_start_par_thread in *);
+      try (find_eapply_lem_hyp start_par_subprocess_axiom);
+      simpl in *; repeat find_rewrite;
+      repeat (find_injection; ff));
+    (* At this point the only build_cvm hyp is the t1 one — find it. *)
+    match! goal with
+    | [ h : build_cvm _ _ _ _ = (res _, _) |- _ ] =>
+      eapply IHt1 in $h as ?; eauto; ff; try lia;
+      eapply cvm_spans in $h as ?; eauto; ff
+    end;
+    (* Now bring in the t2 result via parallel_vm_thread_axiom. *)
     try (find_eapply_lem_hyp parallel_vm_thread_axiom);
-    try (unfold do_start_par_thread in *);
-
-        try (find_eapply_lem_hyp start_par_subprocess_axiom);
-    simpl in *; repeat find_rewrite;
-    repeat (find_injection; ff)));
-    eapply IHt1 in Heq1 as ?; eauto; ff; try lia;
-    eapply cvm_spans in Heq1 as ?; eauto; ff;
     try (repeat find_rewrite; simpl in *;
       eapply events_range; eauto; ff; fail);
     repeat find_rewrite; try lia;
@@ -1229,7 +1234,7 @@ Proof.
     erewrite events_events_fix_eq in *; ff;
     assert (n = List.length evs2) by (
       repeat (find_eapply_lem_hyp events_fix_range); eauto; ff);
-    ff.
+    ff).
 Qed.
 
 Corollary cvm_trace_respects_events_default : forall G,


### PR DESCRIPTION
## Summary

This PR implements true parallel execution of `bpar` Copland terms via forked CVM subprocess instances, then eliminates a race condition in how those subprocesses receive their configuration.

**Phase 1 – Sequential subprocess baseline** (commits `4f03dac`–`2127e6a`): introduced subprocess CVM infrastructure. A `parallel_vm_thread` stub forks the CVM binary and communicates via a shared `/tmp/cvm_startup.json` startup file plus a per-request stdin payload.

**Phase 2 – True parallel execution** (commits `3904dfa`–`8546676`): split the sequential stub into non-blocking `start_par_subprocess` + `collect_par_subprocess` primitives backed by new `ffispawn_par_process` / `fficollect_par_process` C FFI functions. The parent CVM launches the subprocess and immediately continues executing `t1` of `bpar`, then blocks only at `collect` time. PID-namespaced handle files (`/tmp/cvm_par_<pid>_<loc>.handle`) prevent nested `bpar` subprocesses from colliding.

**Option B – Inline bundle / eliminate startup file** (commits `f60dced`–`ef933c8`): replaced the shared `/tmp/cvm_startup.json` with an inline bundle JSON sent atomically on subprocess stdin. No file race condition possible between concurrent protocols with different manifests.

---

## Detailed changes

### `theories/St.v`
- Introduced `CVM_Config` record wrapping `Session_Config` with `cc_asp_bin`, `cc_cvm_bin`, and `cc_manifest`
- Changed `CVM A` monad type from `Config Session_Config ...` to `Config CVM_Config ...`
- Added `CVM_ask : CVM CVM_Config` and `CVM_ask_session : CVM Session_Config` (backward-compat projection)

### `theories/Monad.v`
- `get_config` now uses `CVM_ask_session` (all existing call-sites unchanged)
- Added `get_cvm_config : CVM CVM_Config := CVM_ask`
- `start_par_thread` passes `p` to `do_start_par_thread`
- `do_wait_par_thread` switched from `parallel_vm_thread` to `collect_par_subprocess`

### `theories/IO_Axioms.v`
- Added `start_par_subprocess : CVM unit` and `collect_par_subprocess : Result Evidence CVM_Error` (Phase 2 split primitives)

### `theories/IO_Utils.v`
- `do_start_par_thread` wires the `p` argument through to `start_par_subprocess`

### `theories/Cvm_Axioms.v`
- `parallel_vm_thread_axiom` repointed to `collect_par_subprocess` and updated for `CVM_Config`
- Added `start_par_subprocess_axiom : forall i p e t, start_par_subprocess i p e t = CVM_ret tt`
- `do_remote_res_axiom` restructured to existentially witness `cfg' : CVM_Config` with matching `session_context`

### `theories/AM_Handler.v`
- Added `term_has_bpar`, `build_startup_json`, `CVM_STARTUP_FILE` helpers
- `handle_AM_request` gains a `cvm_binary_opt` parameter; builds `CVM_Config` and passes it as the monad reader to `build_cvm`
- Startup file write removed (Option B); warning retained for missing `--cvm_binary` with `bpar` terms

### `theories/FrontEnd.v`
- Added `--cvm_binary` CLI argument
- Added stdin mode (no-arg invocation): reads a single inline bundle JSON `{cvm_binary, manifest, asp_bin, request}` from stdin and dispatches to `handle_AM_request` — no startup file read
- CLI mode: request value no longer pre-parsed to JSON; passed as raw string to `handle_AM_request`

### `theories/Verification.v`
- Updated throughout for `CVM_Config`: `session_plc sc` → `session_plc (cc_session sc)`, etc.
- `cvm_preserves_wf_Evidence` att case updated to use the new `do_remote_res_axiom` existential form

### `stubs/FFI/sys_ffi.c`
- `ffispawn_par_process`: non-blocking fork/exec; writes stdin, closes it, returns `(stdout_read_fd, child_pid)` immediately without waiting
- `fficollect_par_process`: blocks on read/waitpid, returns child stdout via buffer-manager protocol
- `ffic_getpid`: returns calling process PID for handle-file namespacing

### `stubs/FFI/SysFFI.cml`
- `c_spawn_par_process`: CML wrapper for `ffispawn_par_process`, returns `(fd, pid)` pair
- `c_collect_par_process`: CML wrapper for `fficollect_par_process`
- `c_getpid`: CML wrapper for `ffic_getpid`

### `stubs/IO_Axioms.cml`
- `parallel_vm_thread`: kept for reference; still reads startup file (Phase 1 legacy, no longer called from Rocq)
- `start_par_subprocess`: rewritten as 6-arg CVM monad function; extracts config from monad `cfg` arg, reconstructs `att_sess` via `session_config_decompiler`, builds inline bundle JSON `{cvm_binary, manifest, asp_bin, request}`, calls `c_spawn_par_process`
- `collect_par_subprocess`: reads PID-namespaced handle file, calls `c_collect_par_process`, deserializes response
- `par_write_handle` / `par_read_handle`: handle file I/O helpers

---

## Test plan
- [ ] `dune build` passes with no errors (only expected extraction warnings)
- [ ] Verification.v proofs all pass (no new `Admitted`)
- [ ] Single-branch `bpar` attestation produces correct evidence
- [ ] Nested `bpar` (subprocess spawning its own subprocess) does not collide on handle files
- [ ] Concurrent protocols with different manifests do not race on config delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
